### PR TITLE
Update Rack, add SameSite Lax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.4.6'
+ruby '2.6.6'
 
 # https://stackoverflow.com/questions/41454333/meaning-of-new-block-git-sourcegithub-in-gemfile
 git_source(:github) do |repo_name|
@@ -17,6 +17,7 @@ gem "mutations"
 gem "octokit", "~> 4.0"
 gem "restpack_serializer", "~> 0.6"
 gem "warden-github-rails", "~> 1.1.0"
+gem "rack", "~> 2.2.2"
 gem "rack-cors", :require => "rack/cors"
 gem "sprockets"
 gem "slack-ruby-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (3.12.1)
-    rack (2.0.7)
+    rack (2.2.2)
     rack-cors (1.0.3)
     rack-proxy (0.6.5)
       rack
@@ -241,6 +241,7 @@ DEPENDENCIES
   pg (~> 0.18)
   pry-rails
   puma (~> 3.7)
+  rack (~> 2.2.2)
   rack-cors
   rails (= 5.2.3)
   react-rails
@@ -257,7 +258,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 2.4.6p354
+   ruby 2.6.6p146
 
 BUNDLED WITH
    1.17.3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Features include:
 
 ## Setting up
 
-##### Ruby version: `2.4.6`
+##### Ruby version: `2.6.6`
 ##### Rails version: `5.2.3`
 ##### Node version: `7`
 ##### Database: postgresql (don't forget to start up postgres)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: 'pull_request_feed_session_store'
+Rails.application.config.session_store :cookie_store, key: 'pull_request_feed_session_store', same_site: :lax


### PR DESCRIPTION
Let's get explicit about what type of SameSite setting we use across the
board. Google's going to make Lax the default for Chrome, with other browsers
(maybe) following suit with an unknown ETA. Let's just head this one off at the
pass and use Lax everywhere.

Rack 2.1.0 added `SameSite=None` support which might be something useful
if `SameSite=Lax` breaks things.

Bumped Ruby to 2.6.6 because 2.4 is EOL
